### PR TITLE
Fix recipes not appearing in the EPUB

### DIFF
--- a/src/build_epub.sh
+++ b/src/build_epub.sh
@@ -64,7 +64,7 @@ process_chapter() {
 	# Add an HTML ID to the header for easy navigation.
 	/<h1>/ { gsub("<h1>", "<h1 id=\"'"$id"'\">") }
 	# Remove the list of chapters at the beginning of each chapter.
-	/<ul/ { inside_ul = 1 }
+	/<ul class='"'"'col2'"'"'>/ { inside_ul = 1 }
 	!inside_ul
 	/<\/ul>/ { inside_ul = 0 }
 	' "$1"


### PR DESCRIPTION
A better solution would be to move the list of chapters to a separate
file instead of having it in each chapter so that it doesn't need to be
removed but this works for now.